### PR TITLE
Add IPinfo API to Geocoding & Maps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Most requested APIs for common application features:
 |-----|-------------|------|------------|
 | [Mapbox](https://docs.mapbox.com/api/) | <details><summary>Maps, geocoding, and location services</summary>Add interactive maps, geocoding, and navigation features to your applications with customizable styling.</details> | API Key | Medium |
 | [OpenStreetMap Nominatim](https://nominatim.org/release-docs/develop/api/Overview/) | <details><summary>Free geocoding service using OpenStreetMap data</summary>Convert addresses to coordinates and vice versa using open-source mapping data.</details> | None | Easy |
-
+| [IPinfo](https://ipinfo.io/developers/) | <details><summary>IP address lookup and geolocation service</summary>Get location, ISP, and organization info for IPs—ideal for location-based customization or analytics.</details> | None | Easy |
 ---
 
 ## Government & Public Data


### PR DESCRIPTION
Added IPinfo, a free IP geolocation API, under the Geocoding & Maps section. No authentication required. Useful for location-based services and analytics. Difficulty: Easy.
Label: api-fellowship
