### PR TITLE
Added Trace.moe API to Anime & Manga section

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Most requested APIs for common application features:
 |-----|-------------|------|------------|
 | [Jikan](https://jikan.moe/) | <details><summary>Unofficial MyAnimeList API for anime and manga data</summary>Access anime/manga information, ratings, reviews, and recommendations for building anime databases and recommendation systems.</details> | None | Easy |
 | [AniList API](https://anilist.gitbook.io/anilist-apiv2-docs/) | <details><summary>GraphQL API for anime and manga data</summary>Comprehensive anime/manga database with user data, statistics, and social features.</details> | OAuth | Medium |
+| [Trace.moe](https://soruly.github.io/trace.moe/) | <details><summary>Anime scene search engine</summary>Find out which anime a scene is from by uploading an image or using a video frame. Useful for anime recognition tools.</details> | None | Easy |
+
 
 ---
 


### PR DESCRIPTION
This PR adds the Trace.moe API – a free anime scene search tool – under the Anime & Manga section. 
It allows users to upload an image or frame and find out which anime it's from. 
No authentication is required, and it's easy to use.
