### PR TITLE
Add GNews API to public APIs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Most requested APIs for common application features:
 |-----|-------------|------|------------|
 | [NewsAPI](https://newsapi.org/) | <details><summary>News articles from thousands of sources worldwide</summary>Build news aggregators, current events apps, and media monitoring tools with real-time news data.</details> | API Key | Easy |
 | [Guardian API](https://open-platform.theguardian.com/) | <details><summary>Access to The Guardian's content and archives</summary>Get articles, multimedia content, and editorial data from The Guardian newspaper.</details> | API Key | Easy |
+| [GNews API](https://gnews.io/) | <details><summary>Access to news articles from thousands of sources</summary>Search, filter, and retrieve news content using the free-tier GNews API.</details> | API Key | Easy |
 
 ---
 


### PR DESCRIPTION
## Summary

Added the [GNews API](https://gnews.io/) to the README as part of the Keploy Public APIs Collection.

## About the API

GNews provides access to the latest news articles from various global sources. It allows filtering by keyword, language, region, and more.

- Auth: API Key (free tier available)
- HTTPS: Yes
- Difficulty: Easy

## Why this contribution?

This addition helps developers find a reliable and simple news API for use in their projects. It aligns with Keploy’s goal of curating valuable public APIs.

## Checklist

- [x] Added API in the correct Markdown table format
- [x] Verified the API is publicly available and functional
- [x] Followed contribution guidelines
