### PR TITLE
Added IPify API to Open Data & Analytics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,9 @@ Most requested APIs for common application features:
 
 ---
 
+| [IPify](https://www.ipify.org/) | Simple public IP address API for IP address lookup | None | Easy |
+
+
 ## Open Source Projects
 
 | API | Description | Auth | Difficulty |


### PR DESCRIPTION
Added the IPify API — a simple and free public IP address lookup service — to the Open Data & Analytics section. No authentication required and easy to use for testing or IP-based features. Closes #25
