### PR TITLE
Add Open‑Meteo API to Environment & Weather section

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Most requested APIs for common application features:
 | [AirVisual](https://www.iqair.com/air-pollution-data-api) | <details><summary>Air quality data for cities worldwide</summary>Get real-time air quality information, pollution data, and health recommendations.</details> | API Key | Easy |
 | [Open‑Meteo](https://open-meteo.com) | <details><summary>Free weather forecasts with hourly data</summary>Get accurate hourly weather data like temperature, wind speed, and precipitation for any location without needing an API key. Great for prototypes and educational use.</details> | No | Easy |
 
+
 ---
 
 ## Finance & Banking

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Most requested APIs for common application features:
 |-----|-------------|------|------------|
 | [OpenWeatherMap](https://openweathermap.org/api) | <details><summary>Weather data including current conditions, forecasts, and historical data</summary>Add weather information to your applications with current conditions, forecasts, and weather maps.</details> | API Key | Easy |
 | [AirVisual](https://www.iqair.com/air-pollution-data-api) | <details><summary>Air quality data for cities worldwide</summary>Get real-time air quality information, pollution data, and health recommendations.</details> | API Key | Easy |
+| [Open‑Meteo](https://open-meteo.com) | <details><summary>Free weather forecasts with hourly data</summary>Get accurate hourly weather data like temperature, wind speed, and precipitation for any location without needing an API key. Great for prototypes and educational use.</details> | No | Easy |
 
 ---
 


### PR DESCRIPTION
- Added [Open‑Meteo](https://open-meteo.com) under the Environment & Weather category.
- It's a free, no-auth weather API that offers hourly forecasts including temperature, wind speed, and precipitation.
- Verified to be publicly accessible and HTTPS secure.
