### PR TITLE
Added XKCD Comics API under Comics & Entertainment category

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,15 @@ Most requested APIs for common application features:
 
 ---
 
+## Comics & Entertainment
+
+| API | Description | Auth | Difficulty |
+|-----|-------------|------|------------|
+| [XKCD Comics](https://xkcd.com/json.html) | <details><summary>Get info from XKCD webcomic</summary>Provides JSON data for XKCD comics including title, image URL, transcript, and more. Useful for fun apps and bots.</details> | No | Easy |
+
+---
+
+
 ## Development & Testing
 
 | API | Description | Auth | Difficulty |


### PR DESCRIPTION
This PR adds the XKCD Comics API to the public API list under a new category "Comics & Entertainment". This API provides JSON responses with details like comic number, title, image URL, alt text, and more. It requires no authentication and is simple to integrate.
