### PR TITLE
Add Open‑Meteo API to Environment & Weather section

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Most requested APIs for common application features:
 |-----|-------------|------|------------|
 | [OpenWeatherMap](https://openweathermap.org/api) | <details><summary>Weather data including current conditions, forecasts, and historical data</summary>Add weather information to your applications with current conditions, forecasts, and weather maps.</details> | API Key | Easy |
 | [AirVisual](https://www.iqair.com/air-pollution-data-api) | <details><summary>Air quality data for cities worldwide</summary>Get real-time air quality information, pollution data, and health recommendations.</details> | API Key | Easy |
+| [Open-Meteo](https://open-meteo.com/en/docs) | <details><summary>Free weather API with forecasts and historical weather data</summary>Provides high-resolution weather data tailored for specific locations. No authentication needed.</details> | No | Easy |
 
 ---
 


### PR DESCRIPTION
This PR adds Open-Meteo, a free and no-auth weather forecast API, to the Environment & Weather section of the public APIs list.
